### PR TITLE
fix: await startNotifications() calls

### DIFF
--- a/src/ble.ts
+++ b/src/ble.ts
@@ -79,19 +79,19 @@ export class ImprovBluetoothLE extends EventTarget {
       );
     }
 
-    this._currentStateChar.startNotifications();
+    await this._currentStateChar.startNotifications();
     this._currentStateChar.addEventListener(
       "characteristicvaluechanged",
       (ev: any) => this._handleImprovCurrentStateChange(ev.target.value)
     );
 
-    this._errorStateChar.startNotifications();
+    await this._errorStateChar.startNotifications();
     this._errorStateChar.addEventListener(
       "characteristicvaluechanged",
       (ev: any) => this._handleImprovErrorStateChange(ev.target.value)
     );
 
-    this._rpcResultChar.startNotifications();
+    await this._rpcResultChar.startNotifications();
     this._rpcResultChar.addEventListener(
       "characteristicvaluechanged",
       (ev: any) => this._handleImprovRPCResultChange(ev.target.value)

--- a/src/ble.ts
+++ b/src/ble.ts
@@ -79,23 +79,23 @@ export class ImprovBluetoothLE extends EventTarget {
       );
     }
 
-    await this._currentStateChar.startNotifications();
     this._currentStateChar.addEventListener(
       "characteristicvaluechanged",
       (ev: any) => this._handleImprovCurrentStateChange(ev.target.value)
     );
+    await this._currentStateChar.startNotifications();
 
-    await this._errorStateChar.startNotifications();
     this._errorStateChar.addEventListener(
       "characteristicvaluechanged",
       (ev: any) => this._handleImprovErrorStateChange(ev.target.value)
     );
+    await this._errorStateChar.startNotifications();
 
-    await this._rpcResultChar.startNotifications();
     this._rpcResultChar.addEventListener(
       "characteristicvaluechanged",
       (ev: any) => this._handleImprovRPCResultChange(ev.target.value)
     );
+    await this._rpcResultChar.startNotifications();
 
     const curState = await this._currentStateChar.readValue();
     const errorState = await this._errorStateChar.readValue();


### PR DESCRIPTION
Otherwise we get random, unrelated, errors during provisioning, for "Unknown reason".

See 

- https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTCharacteristic/startNotifications
- https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-startnotifications
`The startNotifications() method, when invoked, MUST return a new Promise`

