### PR TITLE
Fix event name for state change

### DIFF
--- a/src/ble.ts
+++ b/src/ble.ts
@@ -179,7 +179,7 @@ export class ImprovBluetoothLE extends EventTarget {
     const state = encodedState.getUint8(0) as ImprovCurrentState;
     this.logger.debug("improv current state", state);
     this.currentState = state;
-    this.dispatchEvent(new CustomEvent("state-change"));
+    this.dispatchEvent(new CustomEvent("state-changed"));
   }
 
   private _handleImprovErrorStateChange(encodedState: DataView) {

--- a/src/provision-dialog.ts
+++ b/src/provision-dialog.ts
@@ -113,14 +113,14 @@ class ProvisionDialog extends LitElement {
         <div class="icon">${icon}</div>
         ${label}
       </div>
-      ${showClose &&
-      html`
-        <ib-button
-          slot="primaryAction"
-          dialogAction="ok"
-          label="Close"
-        ></ib-button>
-      `}
+      ${showClose ?
+        html`
+          <ib-button
+            slot="primaryAction"
+            dialogAction="ok"
+            label="Close"
+          ></ib-button>
+        ` : ``}
     `;
   }
 


### PR DESCRIPTION
Fix a typo for the event name "state-changed"